### PR TITLE
Add projects section to main page

### DIFF
--- a/src/data/projects.tsx
+++ b/src/data/projects.tsx
@@ -1,0 +1,48 @@
+const projectsData = {
+  projects: [
+    {
+      title: "Project 1",
+      description: "This is a description of project 1.",
+      image: "https://via.placeholder.com/150",
+      skills: ["React", "TypeScript", "CSS"],
+      githubUrl: "https://github.com/DarthAV/project1",
+    },
+    {
+      title: "Project 2",
+      description: "This is a description of project 2.",
+      image: "https://via.placeholder.com/150",
+      skills: ["JavaScript", "HTML", "CSS"],
+      githubUrl: "https://github.com/DarthAV/project2",
+    },
+    {
+      title: "Project 3",
+      description: "This is a description of project 3.",
+      image: "https://via.placeholder.com/150",
+      skills: ["Python", "Django", "PostgreSQL"],
+      githubUrl: "https://github.com/DarthAV/project3",
+    },
+    {
+      title: "Project 1",
+      description: "This is a description of project 1.",
+      image: "https://via.placeholder.com/150",
+      skills: ["React", "TypeScript", "CSS"],
+      githubUrl: "https://github.com/DarthAV/project1",
+    },
+    {
+      title: "Project 2",
+      description: "This is a description of project 2.",
+      image: "https://via.placeholder.com/150",
+      skills: ["JavaScript", "HTML", "CSS"],
+      githubUrl: "https://github.com/DarthAV/project2",
+    },
+    {
+      title: "Project 3",
+      description: "This is a description of project 3.",
+      image: "https://via.placeholder.com/150",
+      skills: ["Python", "Django", "PostgreSQL"],
+      githubUrl: "https://github.com/DarthAV/project3",
+    },
+  ],
+};
+
+export default projectsData;

--- a/src/pages/sections/Projects.tsx
+++ b/src/pages/sections/Projects.tsx
@@ -1,0 +1,67 @@
+import { Card, CardHeader, Image, Link, Chip } from "@nextui-org/react";
+import projectsData from "../../data/projects";
+import { SectionHeader } from "../../components/SectionHeader";
+
+interface ProjectCardProps {
+  title: string;
+  description: string;
+  image?: string;
+  skills: string[];
+  githubUrl: string;
+}
+
+function ProjectCard({
+  title,
+  description,
+  image,
+  skills,
+  githubUrl,
+}: ProjectCardProps) {
+  return (
+    <Card isBlurred as={Link} href={githubUrl} isExternal isBlock className="h-96 w-72">
+      <CardHeader className="flex flex-col items-center">
+        {image && (
+          <Image
+            alt={title + " image"}
+            height={150}
+            width={150}
+            radius="sm"
+            src={image}
+            className="mb-4"
+          />
+        )}
+        <div className="flex flex-col items-center">
+          <p className="text-lg">{title}</p>
+          <p className="text-md">{description}</p>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {skills.map((skill, index) => (
+              <Chip key={index} size="sm" variant="flat">
+                {skill}
+              </Chip>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+    </Card>
+  );
+}
+
+export function Projects() {
+  return (
+    <div className="justify-evenly">
+      <SectionHeader title="Projects" subtitle="My Personal Projects" />
+      <div className="flex overflow-scroll overflow-x-auto space-x-4">
+        {projectsData.projects.map((project, index) => (
+          <ProjectCard
+            key={index}
+            title={project.title}
+            description={project.description}
+            image={project.image}
+            skills={project.skills}
+            githubUrl={project.githubUrl}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add a Projects section to the main page below the Experience section.

* Create `src/data/projects.tsx` to store projects data with properties like `title`, `description`, `image`, `skills`, and `githubUrl`.
* Create `src/pages/sections/Projects.tsx` to define the `Projects` component.
  * Render projects as cards with an optional image, a short description, and pills for skills/technologies.
  * Add functionality to redirect to the project's GitHub page in a new tab when the card is clicked.
* Update `src/pages/Home.tsx` to include the `Projects` component